### PR TITLE
fixed double onError calling when using WebView

### DIFF
--- a/vkAuth/src/main/java/net/aquadc/vkauth/VkOAuthDialogHolder.java
+++ b/vkAuth/src/main/java/net/aquadc/vkauth/VkOAuthDialogHolder.java
@@ -166,11 +166,6 @@ import static net.aquadc.vkauth.Util.explodeQueryString;
             holder.onSaveInstanceState(outState);
         }
 
-        @Override public void onCancel(DialogInterface dialog) {
-            super.onCancel(dialog);
-            deliverResult();
-        }
-
         @Override public void onDismiss(DialogInterface dialog) {
             super.onDismiss(dialog);
             deliverResult();
@@ -209,11 +204,6 @@ import static net.aquadc.vkauth.Util.explodeQueryString;
         @Override public void onSaveInstanceState(Bundle outState) {
             super.onSaveInstanceState(outState);
             holder.onSaveInstanceState(outState);
-        }
-
-        @Override public void onCancel(DialogInterface dialog) {
-            super.onCancel(dialog);
-            deliverResult();
         }
 
         @Override public void onDismiss(DialogInterface dialog) {


### PR DESCRIPTION
No need to override onCancel in CompatFragment and NativeFragment, because both of them implement Host and OAuthWebViewClient onCancel override already calls host.dismiss()